### PR TITLE
feat: add stop imports button

### DIFF
--- a/src/modules/outline-doc-pusher/OutlineDocPusher.tsx
+++ b/src/modules/outline-doc-pusher/OutlineDocPusher.tsx
@@ -12,7 +12,6 @@ export function OutlineDocPusher () {
   const [isSideFormOpened, setIsSideFormOpened] = useState(false)
 
   const closeSideForm = () => {
-    if (isSideFormLocked) return
     setIsSideFormOpened(false)
     cancelImport()
   }
@@ -27,7 +26,7 @@ export function OutlineDocPusher () {
           </h5>
 
           <label
-            htmlFor='drawer-right'
+            htmlFor='outline-form-open'
             className='btn btn-primary font-bold cursor-pointer! bg-gradient-to-br from-green-400 to-blue-600 hover:bg-gradient-to-bl'
           >
             Push to Outline
@@ -36,7 +35,7 @@ export function OutlineDocPusher () {
       )}
       <input
         type='checkbox'
-        id='drawer-right'
+        id='outline-form-open'
         className='drawer-toggle'
         checked={isSideFormOpened}
         onChange={ev => setIsSideFormOpened(ev.target.checked)}
@@ -45,7 +44,7 @@ export function OutlineDocPusher () {
       <div className='drawer drawer-right'>
         <div className='drawer-content flex flex-col h-full'>
           {isSideFormOpened && (
-            <OutlineForm isLocked={isSideFormLocked} isOpened={isSideFormOpened} closeForm={closeSideForm} />
+            <OutlineForm isLocked={isSideFormLocked} closeForm={closeSideForm} />
           )}
         </div>
       </div>

--- a/src/modules/outline-doc-pusher/OutlineForm.tsx
+++ b/src/modules/outline-doc-pusher/OutlineForm.tsx
@@ -7,14 +7,14 @@ import { OutlineFormLogs } from './OutlineFormLogs'
 import { OutlineFormStatus } from './OutlineFormStatus'
 import classNames from 'classnames'
 import { useLocalTokens } from '@/modules/local-tokens'
+import { OutlineFormStopBtn } from './OutlineFormStopBtn'
 
 export interface IOutlineFormProps {
   isLocked?: boolean
-  isOpened: boolean
   closeForm: () => void
 }
 
-export function OutlineForm ({ isLocked, isOpened, closeForm }: IOutlineFormProps) {
+export function OutlineForm ({ isLocked, closeForm }: IOutlineFormProps) {
   const { selectedItemIds, currentImportStatus, importToOutline, confirmImport } = useClient()
   const { outlineApiToken: apiToken, setApiTokenFor } = useLocalTokens()
   const isProcessing = currentImportStatus?.status === ITEM_STATUS_IMPORTING
@@ -32,7 +32,7 @@ export function OutlineForm ({ isLocked, isOpened, closeForm }: IOutlineFormProp
   }, [apiToken]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <form className='outline-form flex flex-col max-h-full gap-2'>
+    <form className='outline-form flex flex-col max-h-full gap-2' onSubmit={ev => ev.preventDefault()}>
       <h3>Confirm Outline Import</h3>
       <div className='form-field'>
         <label className='form-label'>Outline API Token</label>
@@ -83,16 +83,18 @@ export function OutlineForm ({ isLocked, isOpened, closeForm }: IOutlineFormProp
           </button>
         </div>
         <div className='form-control justify-between mt-2'>
-          <button
-            type='button'
-            className={classNames(
-              'btn w-full cursor-pointer! disabled',
-              isLocked ? 'text-zinc-300' : 'hover:bg-gray-200',
-            )}
-            onClick={closeForm}
-          >
-            {isDone ? 'Close' : 'Hmm.. not sure'}
-          </button>
+          {isProcessing
+            ? (<OutlineFormStopBtn onStop={closeForm} />)
+            : (
+              <button
+                type='button'
+                className={classNames(
+                  'btn w-full cursor-pointer! disabled',
+                  isLocked ? 'text-zinc-300' : 'hover:bg-gray-200',
+                )}
+                onClick={closeForm}
+              >{isDone ? 'Close' : 'Hmm.. not sure'}
+              </button>)}
         </div>
       </div>
     </form>

--- a/src/modules/outline-doc-pusher/OutlineFormStopBtn.tsx
+++ b/src/modules/outline-doc-pusher/OutlineFormStopBtn.tsx
@@ -1,0 +1,25 @@
+export interface IOutlineFormStopBtnProps {
+  onStop: () => void
+}
+
+export function OutlineFormStopBtn ({ onStop }: IOutlineFormStopBtnProps) {
+  return (
+    <>
+      <label className='btn btn-block hover:bg-gray-200' htmlFor='outline-form-cancel'>Stop</label>
+      <input className='modal-state' id='outline-form-cancel' type='checkbox' />
+      <div className='modal'>
+        <label className='modal-overlay' htmlFor='outline-form-cancel' />
+        <div className='modal-content flex flex-col'>
+          <h4 className='text-xl'>Stop Imports</h4>
+          <p>
+            Are you sure you want to stop the ongoing import process?
+          </p>
+          <div className='flex gap-3 mt-3'>
+            <button type='button' className='btn btn-error btn-block hover:bg-red-600' onClick={onStop}>Yes, stop it</button>
+            <label htmlFor='outline-form-cancel' className='btn btn-block hover:bg-gray-200'>No</label>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/modules/simple-mover/Mover.ts
+++ b/src/modules/simple-mover/Mover.ts
@@ -226,6 +226,7 @@ export class Mover implements IMover {
   cancelImports () {
     this.cancelExports()
     if (this._importer) {
+      console.info('[mover] cancel imports')
       this._importer.stopPendingImports()
       this._importer = undefined
     }
@@ -286,6 +287,7 @@ export class Mover implements IMover {
 
   private cancelExports () {
     if (this._exporter) {
+      console.info('[mover] cancel exports')
       this._exporter.stopPendingExports()
       this._exporter = undefined
     }

--- a/src/modules/simple-mover/MoverClient.ts
+++ b/src/modules/simple-mover/MoverClient.ts
@@ -3,6 +3,7 @@ import {
   CLIENT_CONFIRM_IMPORT,
   CLIENT_IMPORT_OUTLINE,
   CLIENT_LIST_DOCS,
+  CLIENT_REJECT_IMPORT,
   ITEM_STATUS_CANCELLED,
   ITEM_STATUS_CONFIRMING,
   ITEM_STATUS_DONE,
@@ -67,6 +68,7 @@ export class MoverClient implements IClient {
     this.handlers.onImportLogs?.([])
     this.clearImportProgress()
 
+    this.socket.emit(CLIENT_REJECT_IMPORT)
     this.setItemStatus({ id: CLIENT_IMPORT_OUTLINE, status: ITEM_STATUS_CANCELLED })
   }
 

--- a/src/modules/simple-mover/MoverServer.ts
+++ b/src/modules/simple-mover/MoverServer.ts
@@ -1,6 +1,6 @@
 import type { Socket } from 'socket.io'
 import type { ICodaItem, IMover, IServer } from './interfaces'
-import { CLIENT_CONFIRM_IMPORT, CLIENT_IMPORT_OUTLINE, CLIENT_LIST_DOCS, SERVER_RETURN_STATUS } from './events'
+import { CLIENT_CONFIRM_IMPORT, CLIENT_IMPORT_OUTLINE, CLIENT_LIST_DOCS, CLIENT_REJECT_IMPORT, SERVER_RETURN_STATUS } from './events'
 import { Mover } from './Mover'
 import { CodaApis } from './apis'
 import { logError } from './lib'
@@ -79,6 +79,21 @@ export class MoverServer implements IServer {
         logError(err, CLIENT_IMPORT_OUTLINE)
         this.socket.emit(SERVER_RETURN_STATUS, {
           id: CLIENT_IMPORT_OUTLINE,
+          status: 'error',
+          message: err.message,
+        })
+      }
+    })
+
+    this.socket.on(CLIENT_REJECT_IMPORT, () => {
+      try {
+        if (!this._mover) throw Error('Mover not initialized through \'handleClientListDocs\'')
+
+        void this._mover.cancelImports()
+      } catch (err: any) {
+        logError(err, CLIENT_REJECT_IMPORT)
+        this.socket.emit(SERVER_RETURN_STATUS, {
+          id: CLIENT_REJECT_IMPORT,
           status: 'error',
           message: err.message,
         })


### PR DESCRIPTION
Resolves #17 

### Required information

#### What features / fixes included in this PR:
- Add a button to stop amid imports to Outline

#### PR Checklist:
- [x] Follow the style of the surrounding code
- [x] Manual tests
- [ ] Write tests to cover all possible scenarios
- [ ] PR has appropriate labels added (needs-testing, needs-review, etc.)
- [ ] For bug-fixing PR, has a push to snapshot failed scenarios triggered by CI

---

### Nice to have information

#### Related Flow Diagram

https://coderpush.getoutline.com/doc/versions-W3KKy77BIw#h-diagram

<img width="719" alt="image" src="https://github.com/CoderPush/coda-mover/assets/13363340/83df05d8-d800-4d14-bc3f-02b71d2ea042">

#### Screenshots or Records

<img width="311" alt="image" src="https://github.com/CoderPush/coda-mover/assets/13363340/2b2a054f-61aa-41f4-9501-d3bf4f5c6d25">

#### Steps to test:
- Step 1
- Step 2

#### Other concerns:
_Any other thoughts or ideas on further improvement_